### PR TITLE
Disable Husky in CI to prevent helm from failing on containerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ FROM base as build
 COPY ./package*.js* /opt/app-root/src/
 RUN npm set progress=false && \
   npm config set depth 0 && \
+  npm set-script prepare "" && \
+  npm ci --only-production && \
   npm install
 
 COPY ./config /opt/app-root/src/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ FROM base as build
 COPY ./package*.js* /opt/app-root/src/
 RUN npm set progress=false && \
   npm config set depth 0 && \
-  npm set-script prepare "" && \
-  npm ci --only-production && \
+  npm ci --only-production --ignore-scripts && \
   npm install
 
 COPY ./config /opt/app-root/src/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ FROM base as build
 COPY ./package*.js* /opt/app-root/src/
 RUN npm set progress=false && \
   npm config set depth 0 && \
-  npm ci --only-production --ignore-scripts && \
-  npm install
+  npm ci --only-production --ignore-scripts
 
 COPY ./config /opt/app-root/src/config
 COPY ./public /opt/app-root/src/public

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "lint-staged": {
     "./**/*.{js,scss,html,png}": [
-      "npm run build",
-      "git add"
+      "npm run build"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Disabled npm prepare in dockerfile in order to allow CI to build helm image