### PR TITLE
Promote to master (#76)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM base as build
 COPY ./package*.js* /opt/app-root/src/
 RUN npm set progress=false && \
   npm config set depth 0 && \
-  npm install
+  npm ci --only-production --ignore-scripts
 
 COPY ./config /opt/app-root/src/config
 COPY ./public /opt/app-root/src/public

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "lint-staged": {
     "./**/*.{js,scss,html,png}": [
-      "npm run build",
-      "git add"
+      "npm run build"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Disable Husky in CI to prevent helm from failing on containerize (#76)

* Change npm install from initial install to npm ci with ignoring scripts and in prod mode

* Removing git add for the husky pre-commit lint-staged task